### PR TITLE
fixed friendship uniqueness to work correctly with all users

### DIFF
--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -6,7 +6,12 @@ class FriendshipsController < ApplicationController
   end
 
   def create
-    Friendship.create(friendship_params)
+    if Friendship.exists?(friendship_params)
+        redirect_to users_path
+    else
+      Friendship.create(friendship_params)
+        redirect_to users_path
+    end
   end
 
   private

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -1,6 +1,4 @@
 class Friendship < ApplicationRecord
   belongs_to :initiator, class_name: "User"
   belongs_to :contact, class_name: "User"
-
-  validates :contact, uniqueness: true
 end

--- a/db/migrate/20220613161917_add_unique_to_friendships.rb
+++ b/db/migrate/20220613161917_add_unique_to_friendships.rb
@@ -1,0 +1,5 @@
+class AddUniqueToFriendships < ActiveRecord::Migration[6.1]
+  def change
+    add_index :friendships, [:initiator_id, :contact_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_30_191338) do
+ActiveRecord::Schema.define(version: 2022_06_13_161917) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 2022_05_30_191338) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["contact_id"], name: "index_friendships_on_contact_id"
+    t.index ["initiator_id", "contact_id"], name: "index_friendships_on_initiator_id_and_contact_id", unique: true
     t.index ["initiator_id"], name: "index_friendships_on_initiator_id"
   end
 


### PR DESCRIPTION
I noticed that when trying to make a friendship between a user that was already a friend elsewhere the action would not complete and the database would roll back the creation of friendship.

I have re migrated the friendship table to include `add_index :friendships, [:initiator_id, :contact_id], unique: true` at the end

This way the database table will check if the 'friendship' is unique. I also reconfigured the Create method in the Friendships_controller below to reflect this change. **You will need to DB:MIGRATE to get this working. (Maybe drop too)**

`  def create
    if Friendship.exists?(friendship_params)
        redirect_to users_path
    else
      Friendship.create(friendship_params)
        redirect_to users_path
    end
  end`